### PR TITLE
without "name" attribute more than one radio field can be active

### DIFF
--- a/resources/views/bootstrap-4/form-radio.blade.php
+++ b/resources/views/bootstrap-4/form-radio.blade.php
@@ -4,9 +4,8 @@
 
         @if($isWired())
             wire:model{!! $wireModifier() !!}="{{ $name }}"
-        @else
-            name="{{ $name }}"
         @endif
+            name="{{ $name }}"
 
         value="{{ $value }}"
 


### PR DESCRIPTION
When using livewire and @wire in the form, this blade template will remove the "name" attribute from the radio button. This leads to the situation where the user could activate more than one radio button at the same time.

Please correct me, if I'm on the wrong track here.